### PR TITLE
Dittybopper using jsonnet dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Pull requests are encouraged. If you find this tool useful, please help extend i
 ```
 $ git clone https://github.com/cloud-bulldozer/dittybopper.git
 $ cd dittybopper
-$ ./deploy.sh [-c <kubectl_cmd>] [-m <host1> <host2> <host3>] [-n <namespace>] [-p <grafana_pwd>]
+$ ./deploy.sh [-c <kubectl_cmd>] [-n <namespace>] [-p <grafana_pwd>]
 ```
 
 See `./deploy.sh -h` for help.

--- a/syncer/Dockerfile
+++ b/syncer/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+RUN microdnf install git make tar
+WORKDIR /dittybopper-syncer
+RUN chmod 775 /dittybopper-syncer
+COPY entrypoint.sh /bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]

--- a/syncer/entrypoint.sh
+++ b/syncer/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 arsenal=https://github.com/cloud-bulldozer/arsenal.git
-dashboards="ocp-performance.json api-performance-overview.json etcd-on-cluster-dashboard.json"
 
 git clone ${arsenal} --depth=1
 make -C arsenal/jsonnet build
@@ -11,7 +10,7 @@ while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/heal
   sleep 5
 done
 
-for d in ${dashboards}; do
+for d in ${DASHBOARDS}; do
   if [[ ! -f $d ]]; then
     echo "Dashboard ${d} not found"
     continue

--- a/syncer/entrypoint.sh
+++ b/syncer/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+arsenal=https://github.com/cloud-bulldozer/arsenal.git
+dashboards="ocp-performance.json api-performance-overview.json etcd-on-cluster-dashboard.json"
+
+git clone ${arsenal} --depth=1
+make -C arsenal/jsonnet build
+pushd arsenal/jsonnet/rendered
+while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health) != "200" ]]; do 
+  echo "Grafana still not ready, waiting 5 seconds"
+  sleep 5
+done
+
+for d in ${dashboards}; do
+  if [[ ! -f $d ]]; then
+    echo "Dashboard ${d} not found"
+    continue
+  else
+    echo "Importing dashboard $d"
+    dashboard=$(cat ${d})
+    echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" | \
+      curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@- \
+      "http://admin:${GRAFANA_ADMIN_PASSWORD}@localhost:3000/api/dashboards/db" -o /dev/null
+  fi    
+done
+
+echo "Dittybopper ready"
+exec sleep inf

--- a/templates/dittybopper.yaml.template
+++ b/templates/dittybopper.yaml.template
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: dittybopper
-        image: docker.io/grafana/grafana:6.7.2
+        image: docker.io/grafana/grafana:7.1.4
         ports:
         - name: sc-grafana-http
           containerPort: 3000
@@ -57,7 +57,11 @@ spec:
           name: sc-grafana-config
         - mountPath: /etc/grafana/provisioning/datasources
           name: sc-ocp-prom
-
+      - name: dittybopper-syncer
+        env:
+        - name: GRAFANA_ADMIN_PASSWORD
+          value: ${GRAFANA_ADMIN_PASSWORD}
+        image: quay.io/cloud-bulldozer/dittybopper-syncer:latest
       volumes:
       - name: sc-grafana-config
         configMap:

--- a/templates/dittybopper.yaml.template
+++ b/templates/dittybopper.yaml.template
@@ -61,6 +61,8 @@ spec:
         env:
         - name: GRAFANA_ADMIN_PASSWORD
           value: ${GRAFANA_ADMIN_PASSWORD}
+        - name: DASHBOARDS
+          value: ${DASHBOARDS}
         image: quay.io/cloud-bulldozer/dittybopper-syncer:latest
       volumes:
       - name: sc-grafana-config


### PR DESCRIPTION
Modifying dittybopper template to add a sidecar container which syncs the new Jsonnet based dashboards available at arsenal.
Also deprecate the -m flag as is no longer required now.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>